### PR TITLE
CFE_FS_WriteHeader bug

### DIFF
--- a/cfe/fsw/cfe-core/src/fs/cfe_fs_api.c
+++ b/cfe/fsw/cfe-core/src/fs/cfe_fs_api.c
@@ -158,7 +158,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
             /*
             ** Write header structure...
             */
-            Result = OS_write(FileDes, Hdr, ExpectedSize);
+            Result = OS_write(FileDes, LocalBuffer, ExpectedSize);
 
             /*
              * Fixup the return status to match what had been done


### PR DESCRIPTION
CFE_FS_WriteHeader was writing the unpacked file header as opposed to the packed object.  While the packed and unpacked objects have the same size the unpacked object may have a different endianness. For example the content type would show up as '1EFc' instead of 'cFE1' when looking at the output file in a hex editor.

This fix writes the packed LocalBuffer to file instead of the unpacked Hdr object.