### PR TITLE
Cmd packing

### DIFF
--- a/cfe/fsw/cfe-core/src/fs/cfe_fs_api.c
+++ b/cfe/fsw/cfe-core/src/fs/cfe_fs_api.c
@@ -158,7 +158,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
             /*
             ** Write header structure...
             */
-            Result = OS_write(FileDes, Hdr, ExpectedSize);
+            Result = OS_write(FileDes, LocalBuffer, ExpectedSize);
 
             /*
              * Fixup the return status to match what had been done


### PR DESCRIPTION
The CFE_SB_EDS_PackOutputMessage function is not sufficient for packing command messages.  There is only one step in the packing process which cannot handle EDS objects that have constraints such as command codes. This is sufficient for packing telemetry messages in the TO_LAB app as telemetry message typically don't have constraints and the correct EDS object can be obtained from the call to CFE_MissionLib_GetArgumentType.

Additions:
Mirroring the two step unpacking process in CFE_SB_EDS_UnpackInputMessage, there is now a two step packing process to handle if any constraints are found.

Deletions:
The first part of the function that created an EdsId from a base command or telemetry packet was unnecessary.  With the input packet header the appropriate starting point for the EdsId is found via CFE_MissionLib_GetArgumentType which overwrites the EdsId set at the beginning.

I've tested this function using both TO_LAB and an EDS version of the Data Storage App.  The former is able to pack telemetry messages and the latter is able to pack both telemetry and command messages and write them to a file.

