### PR TITLE
Table verification bug fixes.

### DIFF
--- a/cfe/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/cfe/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -41,6 +41,7 @@
 #include "cfe_error.h"
 #include "cfe_sb_events.h"
 #include "cfe_sb_eds_db.h"
+#include "edslib_init.h"
 
 #include "base_types_eds_dictionary.h"
 #include "ccsds_spacepacket_eds_dictionary.h"
@@ -144,6 +145,11 @@ int32 CFE_SB_EarlyInit (void) {
     CFE_SB_EDS_RegisterGlobal(&BASE_TYPES_DATATYPE_DB);
     CFE_SB_EDS_RegisterGlobal(&CCSDS_SPACEPACKET_DATATYPE_DB);
 
+    /*
+     * Call the EdsLib initilization function.
+     * This populates the CRC lookup tables in EdsLib.
+     */
+    EdsLib_Initialize();
 
     return Stat;
 

--- a/cfe/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/cfe/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -1141,7 +1141,7 @@ int32 CFE_TBL_LoadFromFileAndDecode(const char *AppName, CFE_TBL_LoadBuff_t *Wor
          */
         if (Status == CFE_SUCCESS)
         {
-            CFE_TBL_DecodeFromMemory(ScratchBufferPtr->BufferPtr, WorkingBufferPtr, RegRecPtr);
+            Status = CFE_TBL_DecodeFromMemory(ScratchBufferPtr->BufferPtr, WorkingBufferPtr, RegRecPtr);
         }
 
         strncpy(WorkingBufferPtr->DataSource, Filename, sizeof(WorkingBufferPtr->DataSource)-1);


### PR DESCRIPTION
There were two bugs related to table verification via CRC in EdsLib
  - The CRC lookup tables were not being initialized, so any CRC calculation would result in 0 regardless of the input table
  - Despite the CRC calculation always giving 0, the table verification would still return with a success.

The fixes for both bugs are as follows.
 - The CRC lookup tables are initialized with a call to EdsLib_Initialize.  I put the call within the CFE_SB_EarliyInit function.  If there is a better place for this call feel free to change.
 - The return status from the table verification is now saved so if the CRC check fails it will get passed back to the parent function.

With both of these fixes in place I've been able to successfully read in table that have a CRC check.