### PR TITLE
Fix illegal characters in resolved XML output

### DIFF
--- a/tools/eds/cfecfs/edsmsg/eds/cfe_hdr.xml
+++ b/tools/eds/cfecfs/edsmsg/eds/cfe_hdr.xml
@@ -79,7 +79,7 @@
 		 <ContainerDataType name="CommandHeader" baseType="Message" shortDescription="Complete Command Packet Header">
 			 <ConstraintSet>
 				 <ValueConstraint entry="CCSDS.SecHdrFlags" value="Cmd" />
-			 </ConstraintSet>-->
+			 </ConstraintSet>
 			 <EntryList>
 				 <Entry name="Sec" type="CmdSecHdr" shortDescription="Command Secondary Header" />
 			 </EntryList>
@@ -88,7 +88,7 @@
 		 <ContainerDataType name="TelemetryHeader" baseType="Message" shortDescription="Complete Telemetry Packet Header">
 			 <ConstraintSet>
 				 <ValueConstraint entry="CCSDS.SecHdrFlags" value="Tlm" />
-			 </ConstraintSet>-->
+			 </ConstraintSet>
 			 <EntryList>
 				 <Entry name="Sec" type="TlmSecHdr" shortDescription="Telemetry Secondary Header" />
 			 </EntryList>

--- a/tools/eds/tool/scripts/85-seds_write_resolved_xml.lua
+++ b/tools/eds/tool/scripts/85-seds_write_resolved_xml.lua
@@ -73,6 +73,11 @@ local function write_node(output,node,name_prefix)
         attrval = string.format("%g",attrval)
       end
     end
+    if (type(attrval) == "string") then
+      attrval = attrval:gsub("&", "&amp;")
+      attrval = attrval:gsub("<", "&lt;")
+      attrval = attrval:gsub(">", "&gt;")
+    end
     my_attrs = string.format("%s %s=\"%s\"",my_attrs, node.xml_attrname[attr], tostring(attrval))
   end
   local cdata = ""


### PR DESCRIPTION
If the input SEDS file has a short description with an &amp;, the short description in the resolved .xml file will just have &